### PR TITLE
Better NotImplementedError handling in tests

### DIFF
--- a/AlmostDone/CompleteTheProject/test/Tests.kt
+++ b/AlmostDone/CompleteTheProject/test/Tests.kt
@@ -7,11 +7,14 @@ import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import util.*
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         private const val SQUARED = "squared"
@@ -113,6 +116,11 @@ class Test {
         fun beforeAll() {
             mainClazz = mainClass.findClassSafe() ?: throwInternalCourseError()
         }
+    }
+
+    @Test
+    fun smokeTest() {
+        runMainFunction(::main, "$YES$newLineSymbol$SIMBA$newLineSymbol$BORDERS$newLineSymbol")
     }
 
     @Test

--- a/AlmostDone/MultiRowStrings/test/Tests.kt
+++ b/AlmostDone/MultiRowStrings/test/Tests.kt
@@ -4,11 +4,14 @@ import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import util.*
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
 

--- a/AlmostDone/NullSafety/test/Tests.kt
+++ b/AlmostDone/NullSafety/test/Tests.kt
@@ -5,11 +5,14 @@ import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import util.*
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         private const val SQUARED = "squared"

--- a/AlmostDone/NullSafetyPartTwo/test/Tests.kt
+++ b/AlmostDone/NullSafetyPartTwo/test/Tests.kt
@@ -6,11 +6,14 @@ import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import util.*
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         private const val SQUARED = "squared"

--- a/AlmostDone/StringFunctions/test/Tests.kt
+++ b/AlmostDone/StringFunctions/test/Tests.kt
@@ -3,11 +3,14 @@ import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import util.*
 
+@HandleNotImplementedError(["applySquaredFilter"])
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         @JvmStatic

--- a/AlmostDone/StringFunctionsPartTwo/test/Tests.kt
+++ b/AlmostDone/StringFunctionsPartTwo/test/Tests.kt
@@ -3,11 +3,14 @@ import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import util.*
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         @JvmStatic

--- a/AlmostDone/When/test/Tests.kt
+++ b/AlmostDone/When/test/Tests.kt
@@ -4,11 +4,14 @@ import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import util.*
 
+@HandleNotImplementedError(["applyBordersFilter", "applySquaredFilter"])
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         private const val WITH_INDENT =

--- a/AlmostDone/applyBordersFilterFunction/test/Tests.kt
+++ b/AlmostDone/applyBordersFilterFunction/test/Tests.kt
@@ -4,11 +4,14 @@ import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import util.*
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
 

--- a/AlmostDone/choosePictureFunction/test/Tests.kt
+++ b/AlmostDone/choosePictureFunction/test/Tests.kt
@@ -6,11 +6,14 @@ import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import util.*
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         private const val SQUARED = "squared"

--- a/AlmostDone/safeReadLineFunction/test/Tests.kt
+++ b/AlmostDone/safeReadLineFunction/test/Tests.kt
@@ -4,12 +4,15 @@ import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import util.*
 import util.Util.newLineSeparator
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         @JvmStatic

--- a/Chat/askFirstQuestion/test/Tests.kt
+++ b/Chat/askFirstQuestion/test/Tests.kt
@@ -4,7 +4,12 @@ import org.junit.jupiter.api.Test
 import util.Util
 import util.Util.DEFAULT_USER_INPUT
 import util.runMainFunction
+import org.junit.jupiter.api.extension.ExtendWith
+import util.HandleNotImplementedError
+import util.HandleNotImplementedErrorExtension
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     @Test
     fun testSolution() {

--- a/Chat/askSecondQuestion/test/Tests.kt
+++ b/Chat/askSecondQuestion/test/Tests.kt
@@ -4,7 +4,12 @@ import org.junit.jupiter.api.Test
 import util.Util
 import util.Util.DEFAULT_USER_INPUT
 import util.runMainFunction
+import org.junit.jupiter.api.extension.ExtendWith
+import util.HandleNotImplementedError
+import util.HandleNotImplementedErrorExtension
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     @Test
     fun testSolution() {

--- a/Chat/completeTheProject/test/Tests.kt
+++ b/Chat/completeTheProject/test/Tests.kt
@@ -4,7 +4,12 @@ import org.junit.jupiter.api.Test
 import util.Util
 import util.Util.DEFAULT_USER_INPUT
 import util.runMainFunction
+import org.junit.jupiter.api.extension.ExtendWith
+import util.HandleNotImplementedError
+import util.HandleNotImplementedErrorExtension
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     @Test
     fun testSolution() {

--- a/Hangman/CompleteTheProject/test/Tests.kt
+++ b/Hangman/CompleteTheProject/test/Tests.kt
@@ -1,7 +1,4 @@
-import jetbrains.kotlin.course.hangman.generateNewUserWord
-import jetbrains.kotlin.course.hangman.separator
-import jetbrains.kotlin.course.hangman.underscore
-import jetbrains.kotlin.course.hangman.words
+import jetbrains.kotlin.course.hangman.*
 import org.jetbrains.academy.test.system.core.invokeWithArgs
 import org.jetbrains.academy.test.system.core.invokeWithoutArgs
 import org.jetbrains.academy.test.system.core.models.classes.TestClass
@@ -9,12 +6,15 @@ import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.jetbrains.academy.test.system.core.models.method.TestMethod
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.junit.jupiter.api.Test
 import util.*
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         @JvmStatic
@@ -107,6 +107,11 @@ class Test {
             Arguments.of("BOOK", 'A', "$underscoreWithSeparator$underscoreWithSeparator${underscoreWithSeparator}K", null),
             Arguments.of("BOOK", 'B', "$underscoreWithSeparator$underscoreWithSeparator${underscoreWithSeparator}K", "B$separator$underscoreWithSeparator${underscoreWithSeparator}K"),
         )
+    }
+
+    @Test
+    fun smokeTest() {
+        runMainFunction(::main, List(maxAttemptsCount + 1) { "A$newLineSymbol" }.joinToString(""))
     }
 
     @ParameterizedTest

--- a/Hangman/Core/test/Tests.kt
+++ b/Hangman/Core/test/Tests.kt
@@ -5,11 +5,14 @@ import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.jetbrains.academy.test.system.core.models.method.TestMethod
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import util.*
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         @JvmStatic

--- a/Hangman/generateSecretFunction/test/Tests.kt
+++ b/Hangman/generateSecretFunction/test/Tests.kt
@@ -7,12 +7,15 @@ import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.jetbrains.academy.test.system.core.models.method.TestMethod
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.junit.jupiter.api.Test
 import util.*
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         @JvmStatic

--- a/Hangman/getHiddenSecretFunction/test/Tests.kt
+++ b/Hangman/getHiddenSecretFunction/test/Tests.kt
@@ -8,12 +8,15 @@ import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.jetbrains.academy.test.system.core.models.method.TestMethod
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.junit.jupiter.api.Test
 import util.*
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         @JvmStatic

--- a/Hangman/getRoundResultsFunction/test/Tests.kt
+++ b/Hangman/getRoundResultsFunction/test/Tests.kt
@@ -9,12 +9,15 @@ import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.jetbrains.academy.test.system.core.models.method.TestMethod
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.junit.jupiter.api.Test
 import util.*
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         @JvmStatic

--- a/Hangman/isCompleteFunction/test/Tests.kt
+++ b/Hangman/isCompleteFunction/test/Tests.kt
@@ -5,11 +5,14 @@ import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.jetbrains.academy.test.system.core.models.method.TestMethod
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import util.*
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         @JvmStatic

--- a/Hangman/isCorrectInputFunction/test/Tests.kt
+++ b/Hangman/isCorrectInputFunction/test/Tests.kt
@@ -8,12 +8,15 @@ import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.jetbrains.academy.test.system.core.models.method.TestMethod
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.junit.jupiter.api.Test
 import util.*
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         @JvmStatic

--- a/Hangman/safeUserInputFunction/test/Tests.kt
+++ b/Hangman/safeUserInputFunction/test/Tests.kt
@@ -8,12 +8,15 @@ import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.jetbrains.academy.test.system.core.models.method.TestMethod
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.junit.jupiter.api.Test
 import util.*
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         @JvmStatic

--- a/LastPush/CanvasGapsGenerator/test/Tests.kt
+++ b/LastPush/CanvasGapsGenerator/test/Tests.kt
@@ -7,12 +7,15 @@ import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import util.*
 import java.lang.reflect.InvocationTargetException
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         @JvmStatic

--- a/LastPush/CanvasGenerator/test/Tests.kt
+++ b/LastPush/CanvasGenerator/test/Tests.kt
@@ -7,12 +7,15 @@ import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import util.*
 import java.lang.reflect.InvocationTargetException
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         @JvmStatic

--- a/LastPush/CompleteTheProject/test/Tests.kt
+++ b/LastPush/CompleteTheProject/test/Tests.kt
@@ -2,6 +2,7 @@ import jetbrains.kotlin.course.last.push.*
 import org.jetbrains.academy.test.system.core.invokeWithArgs
 import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.params.ParameterizedTest
@@ -10,6 +11,8 @@ import org.junit.jupiter.params.provider.MethodSource
 import util.*
 import java.lang.reflect.InvocationTargetException
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
 
     companion object {
@@ -126,6 +129,14 @@ class Test {
         fun repeatHorizontallyArguments() = canvas().filter{ (p, f) ->
             f.height == 1
         }.toArguments()
+    }
+
+    @Test
+    fun smokeTest() {
+        runMainFunction(
+            ::main,
+            "$YES$newLineSymbol$CUBE$newLineSymbol$CANVAS${newLineSymbol}5${newLineSymbol}5$newLineSymbol"
+        )
     }
 
     @Test

--- a/LastPush/Helpers/src/main/kotlin/jetbrains/kotlin/course/last/push/PreDefinedSymbols.kt
+++ b/LastPush/Helpers/src/main/kotlin/jetbrains/kotlin/course/last/push/PreDefinedSymbols.kt
@@ -3,7 +3,7 @@
 package jetbrains.kotlin.course.last.push
 
 val separator = ' '
-val newLineSymbol = System.lineSeparator().replace("\r\n", "\n")
+val newLineSymbol = System.lineSeparator()
 
 fun getPatternWidth(pattern: String) = pattern.lines().maxOfOrNull { it.length } ?: 0
 

--- a/LastPush/Helpers/test/Tests.kt
+++ b/LastPush/Helpers/test/Tests.kt
@@ -5,12 +5,17 @@ import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
-import util.*
+import util.HandleNotImplementedError
+import util.HandleNotImplementedErrorExtension
+import util.throwInternalCourseError
 import java.lang.reflect.InvocationTargetException
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         @JvmStatic

--- a/LastPush/PatternsGenerator/src/main/kotlin/jetbrains/kotlin/course/last/push/PreDefinedSymbols.kt
+++ b/LastPush/PatternsGenerator/src/main/kotlin/jetbrains/kotlin/course/last/push/PreDefinedSymbols.kt
@@ -3,7 +3,7 @@
 package jetbrains.kotlin.course.last.push
 
 val separator = ' '
-val newLineSymbol = System.lineSeparator().replace("\r\n", "\n")
+val newLineSymbol = System.lineSeparator()
 
 fun getPatternWidth(pattern: String) = pattern.lines().maxOfOrNull { it.length } ?: 0
 

--- a/LastPush/dropTopLineFunction/test/Tests.kt
+++ b/LastPush/dropTopLineFunction/test/Tests.kt
@@ -4,12 +4,15 @@ import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import util.*
 import java.lang.reflect.InvocationTargetException
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         @JvmStatic

--- a/LastPush/getPatternHeightFunction/src/main/kotlin/jetbrains/kotlin/course/last/push/PreDefinedSymbols.kt
+++ b/LastPush/getPatternHeightFunction/src/main/kotlin/jetbrains/kotlin/course/last/push/PreDefinedSymbols.kt
@@ -3,7 +3,7 @@
 package jetbrains.kotlin.course.last.push
 
 val separator = ' '
-val newLineSymbol = System.lineSeparator().replace("\r\n", "\n")
+val newLineSymbol = System.lineSeparator()
 
 fun getPatternWidth(pattern: String) = pattern.lines().maxOfOrNull { it.length } ?: 0
 

--- a/LastPush/getPatternHeightFunction/test/Tests.kt
+++ b/LastPush/getPatternHeightFunction/test/Tests.kt
@@ -1,16 +1,17 @@
-import jetbrains.kotlin.course.last.push.ball
 import jetbrains.kotlin.course.last.push.newLineSymbol
 import org.jetbrains.academy.test.system.core.invokeWithArgs
 import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import util.*
-import java.lang.reflect.InvocationTargetException
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         @JvmStatic

--- a/LastPush/repeatHorizontallyFunction/test/Tests.kt
+++ b/LastPush/repeatHorizontallyFunction/test/Tests.kt
@@ -6,12 +6,15 @@ import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import util.*
 import java.lang.reflect.InvocationTargetException
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         @JvmStatic

--- a/MastermindAdvanced/CompleteTheProject/test/Tests.kt
+++ b/MastermindAdvanced/CompleteTheProject/test/Tests.kt
@@ -1,15 +1,20 @@
+import jetbrains.kotlin.course.mastermind.advanced.generateSecret
+import jetbrains.kotlin.course.mastermind.advanced.main
 import jetbrains.kotlin.course.mastermind.advanced.newLineSymbol
 import org.jetbrains.academy.test.system.core.invokeWithArgs
 import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import util.*
 import java.lang.reflect.InvocationTargetException
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         @JvmStatic
@@ -82,6 +87,11 @@ class Test {
             Arguments.of("ABCD$newLineSymbol", "ABCD", true),
             Arguments.of("ABCD${newLineSymbol}ABC${newLineSymbol}ABCCC${newLineSymbol}ABCI${newLineSymbol}ACI$newLineSymbol", "ABCD", false),
         )
+    }
+
+    @Test
+    fun smokeTest() {
+        runMainFunction(::main, List(4) { generateSecret(4, "ABCDEFGH") + newLineSymbol }.joinToString(""))
     }
 
     @Test

--- a/MastermindAdvanced/generateSecretFunction/test/Tests.kt
+++ b/MastermindAdvanced/generateSecretFunction/test/Tests.kt
@@ -1,13 +1,17 @@
+import jetbrains.kotlin.course.mastermind.advanced.*
 import org.jetbrains.academy.test.system.core.invokeWithArgs
 import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import util.*
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         @JvmStatic
@@ -62,6 +66,11 @@ class Test {
         fun beforeAll() {
             mainClazz = mainClass.findClassSafe() ?: throwInternalCourseError()
         }
+    }
+
+    @Test
+    fun smokeTest() {
+        runMainFunction(::main, List(4) { generateSecret(4, "ABCDEFGH") + newLineSymbol }.joinToString(""))
     }
 
     @ParameterizedTest

--- a/MastermindAdvanced/isCorrectInputFunction/test/Tests.kt
+++ b/MastermindAdvanced/isCorrectInputFunction/test/Tests.kt
@@ -1,13 +1,19 @@
+import jetbrains.kotlin.course.mastermind.advanced.generateSecret
+import jetbrains.kotlin.course.mastermind.advanced.main
+import jetbrains.kotlin.course.mastermind.advanced.newLineSymbol
 import org.jetbrains.academy.test.system.core.invokeWithArgs
 import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import util.*
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         @JvmStatic
@@ -72,6 +78,11 @@ class Test {
             Arguments.of("ABCI", UserInputCorrectness.INCORRECT_ALPHABET),
             Arguments.of("ACI", UserInputCorrectness.INCORRECT_LENGTH),
         )
+    }
+
+    @Test
+    fun smokeTest() {
+        runMainFunction(::main, List(4) { generateSecret(4, "ABCDEFGH") + newLineSymbol }.joinToString(""))
     }
 
     @Test

--- a/MastermindAdvanced/safeUserInputFunction/test/Tests.kt
+++ b/MastermindAdvanced/safeUserInputFunction/test/Tests.kt
@@ -1,15 +1,18 @@
-import jetbrains.kotlin.course.mastermind.advanced.newLineSymbol
+import jetbrains.kotlin.course.mastermind.advanced.*
 import org.jetbrains.academy.test.system.core.invokeWithArgs
 import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import util.*
 import java.lang.reflect.InvocationTargetException
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         @JvmStatic
@@ -82,6 +85,11 @@ class Test {
             Arguments.of("ABCD$newLineSymbol", "ABCD", true),
             Arguments.of("ABCD${newLineSymbol}ABC${newLineSymbol}ABCCC${newLineSymbol}ABCI${newLineSymbol}ACI$newLineSymbol", "ABCD", false),
         )
+    }
+
+    @Test
+    fun smokeTest() {
+        runMainFunction(::main, List(4) { generateSecret(4, "ABCDEFGH") + newLineSymbol }.joinToString(""))
     }
 
     @Test

--- a/TheFirstDateWithProgramming/BuiltinFunctions/test/Tests.kt
+++ b/TheFirstDateWithProgramming/BuiltinFunctions/test/Tests.kt
@@ -3,7 +3,12 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import util.Util
 import util.runMainFunction
+import org.junit.jupiter.api.extension.ExtendWith
+import util.HandleNotImplementedError
+import util.HandleNotImplementedErrorExtension
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     @Test
     fun testSolution() {

--- a/TheFirstDateWithProgramming/CompleteTheProject/test/Tests.kt
+++ b/TheFirstDateWithProgramming/CompleteTheProject/test/Tests.kt
@@ -7,7 +7,11 @@ import org.junit.jupiter.api.Test
 import util.Util
 import util.Util.DEFAULT_USER_INPUT
 import util.runMainFunction
+import org.junit.jupiter.api.extension.ExtendWith
+import util.*
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     @Test
     fun testSolution() {

--- a/TheFirstDateWithProgramming/ProgramEntryPoint/test/Tests.kt
+++ b/TheFirstDateWithProgramming/ProgramEntryPoint/test/Tests.kt
@@ -1,9 +1,14 @@
 import jetbrains.kotlin.course.first.date.main
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import util.HandleNotImplementedError
+import util.HandleNotImplementedErrorExtension
 import util.Util
 import util.runMainFunction
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     @Test
     fun testSolution() {

--- a/TheFirstDateWithProgramming/ReadUserInput/test/Tests.kt
+++ b/TheFirstDateWithProgramming/ReadUserInput/test/Tests.kt
@@ -4,7 +4,11 @@ import org.junit.jupiter.api.Test
 import util.Util
 import util.Util.DEFAULT_USER_INPUT
 import util.runMainFunction
+import org.junit.jupiter.api.extension.ExtendWith
+import util.*
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     @Test
     fun testSolution() {

--- a/TheFirstDateWithProgramming/Variables/test/Tests.kt
+++ b/TheFirstDateWithProgramming/Variables/test/Tests.kt
@@ -6,7 +6,12 @@ import util.Util
 import util.checkListOfVariables
 import util.runMainFunction
 import java.io.File
+import org.junit.jupiter.api.extension.ExtendWith
+import util.HandleNotImplementedError
+import util.HandleNotImplementedErrorExtension
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     @Test
     fun testVariablesInSolution() {

--- a/WarmUp/Collections/test/Tests.kt
+++ b/WarmUp/Collections/test/Tests.kt
@@ -4,6 +4,7 @@ import org.jetbrains.academy.test.system.core.invokeWithArgs
 import org.jetbrains.academy.test.system.core.invokeWithoutArgs
 import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.params.ParameterizedTest
@@ -12,6 +13,8 @@ import org.junit.jupiter.params.provider.MethodSource
 import util.*
 import java.lang.reflect.InvocationTargetException
 
+@HandleNotImplementedError(["countPartialMatches"])
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         @JvmStatic
@@ -47,6 +50,11 @@ class Test {
         fun beforeAll() {
             mainClazz = mainClass.findClassSafe() ?: throwInternalCourseError()
         }
+    }
+
+    @Test
+    fun smokeTest() {
+        runMainFunction(::main, "ABCD$newLineSymbol")
     }
 
     @ParameterizedTest

--- a/WarmUp/CollectionsPartTwo/test/Tests.kt
+++ b/WarmUp/CollectionsPartTwo/test/Tests.kt
@@ -6,12 +6,15 @@ import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import util.*
 import java.lang.reflect.InvocationTargetException
 
+@HandleNotImplementedError(["countPartialMatches"])
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         @JvmStatic
@@ -47,6 +50,11 @@ class Test {
         fun beforeAll() {
             mainClazz = mainClass.findClassSafe() ?: throwInternalCourseError()
         }
+    }
+
+    @Test
+    fun smokeTest() {
+        runMainFunction(::main, "ABCD$newLineSymbol")
     }
 
     @Test

--- a/WarmUp/CompleteTheProject/test/Tests.kt
+++ b/WarmUp/CompleteTheProject/test/Tests.kt
@@ -6,12 +6,15 @@ import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import util.*
 import java.lang.reflect.InvocationTargetException
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         @JvmStatic
@@ -83,6 +86,11 @@ class Test {
         fun beforeAll() {
             mainClazz = mainClass.findClassSafe() ?: throwInternalCourseError()
         }
+    }
+
+    @Test
+    fun smokeTest() {
+        runMainFunction(::main, "ABCD$newLineSymbol")
     }
 
     @Test

--- a/WarmUp/CustomFunctions/test/Tests.kt
+++ b/WarmUp/CustomFunctions/test/Tests.kt
@@ -5,9 +5,12 @@ import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import util.*
 import java.lang.reflect.InvocationTargetException
 
+@HandleNotImplementedError(["countPartialMatches", "countExactMatches"])
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         private lateinit var mainClazz: Class<*>
@@ -17,6 +20,11 @@ class Test {
         fun beforeAll() {
             mainClazz = mainClass.findClassSafe() ?: throwInternalCourseError()
         }
+    }
+
+    @Test
+    fun smokeTest() {
+        runMainFunction(::main, "")
     }
 
     @Test

--- a/WarmUp/If/test/Tests.kt
+++ b/WarmUp/If/test/Tests.kt
@@ -6,12 +6,15 @@ import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import util.*
 import java.lang.reflect.InvocationTargetException
 
+@HandleNotImplementedError(["countPartialMatches", "countExactMatches"])
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         @JvmStatic
@@ -28,6 +31,11 @@ class Test {
         fun beforeAll() {
             mainClazz = mainClass.findClassSafe() ?: throwInternalCourseError()
         }
+    }
+
+    @Test
+    fun smokeTest() {
+        runMainFunction(::main, "ABCD$newLineSymbol")
     }
 
     @ParameterizedTest

--- a/WarmUp/Loops/test/Tests.kt
+++ b/WarmUp/Loops/test/Tests.kt
@@ -4,11 +4,14 @@ import org.jetbrains.academy.test.system.core.invokeWithArgs
 import org.jetbrains.academy.test.system.core.invokeWithoutArgs
 import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.BeforeAll
 import util.*
 import java.lang.reflect.InvocationTargetException
 
+@HandleNotImplementedError(["countPartialMatches", "countExactMatches"])
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         private lateinit var mainClazz: Class<*>
@@ -18,6 +21,11 @@ class Test {
         fun beforeAll() {
             mainClazz = mainClass.findClassSafe() ?: throwInternalCourseError()
         }
+    }
+
+    @Test
+    fun smokeTest() {
+        runMainFunction(::main, "")
     }
 
     @Test

--- a/WarmUp/TypesOfVariables/test/Tests.kt
+++ b/WarmUp/TypesOfVariables/test/Tests.kt
@@ -5,11 +5,12 @@ import org.jetbrains.academy.test.system.core.models.variable.TestVariable
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
-import util.checkListOfVariables
-import util.runMainFunction
-import util.throwInternalCourseError
+import org.junit.jupiter.api.extension.ExtendWith
+import util.*
 import java.io.File
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         private lateinit var mainClazz: Class<*>
@@ -19,6 +20,11 @@ class Test {
         fun beforeAll() {
             mainClazz = mainClass.findClassSafe() ?: throwInternalCourseError()
         }
+    }
+
+    @Test
+    fun smokeTest() {
+        runMainFunction(::main, "")
     }
 
     @Test

--- a/WarmUp/countPartialMatches/test/Tests.kt
+++ b/WarmUp/countPartialMatches/test/Tests.kt
@@ -6,12 +6,15 @@ import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import util.*
 import java.lang.reflect.InvocationTargetException
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         @JvmStatic
@@ -47,6 +50,11 @@ class Test {
         fun beforeAll() {
             mainClazz = mainClass.findClassSafe() ?: throwInternalCourseError()
         }
+    }
+
+    @Test
+    fun smokeTest() {
+        runMainFunction(::main, "ABCD$newLineSymbol")
     }
 
     @ParameterizedTest

--- a/WarmUp/isCompleteFunction/test/Tests.kt
+++ b/WarmUp/isCompleteFunction/test/Tests.kt
@@ -6,9 +6,12 @@ import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import util.*
 import java.lang.reflect.InvocationTargetException
 
+@HandleNotImplementedError(["countPartialMatches", "countExactMatches"])
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         private lateinit var mainClazz: Class<*>
@@ -18,6 +21,11 @@ class Test {
         fun beforeAll() {
             mainClazz = mainClass.findClassSafe() ?: throwInternalCourseError()
         }
+    }
+
+    @Test
+    fun smokeTest() {
+        runMainFunction(::main, "")
     }
 
     @Test

--- a/WarmUp/isLostFunction/test/Tests.kt
+++ b/WarmUp/isLostFunction/test/Tests.kt
@@ -6,12 +6,15 @@ import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import util.*
 import java.lang.reflect.InvocationTargetException
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         @JvmStatic
@@ -57,6 +60,11 @@ class Test {
             Arguments.of(false, 5, 4, false, true),
             Arguments.of(false, 3, 4, false, false),
         )
+    }
+
+    @Test
+    fun smokeTest() {
+        runMainFunction(::main, "ABCD$newLineSymbol")
     }
 
     @Test
@@ -118,7 +126,7 @@ class Test {
             userMethod.invoke(mainClazz, guess, secret)
             val actualOutput = baos.toString("UTF-8").replaceLineSeparator()
             Assertions.assertEquals(expectedOutput, actualOutput) { errorMessage }
-        } catch(e: InvocationTargetException) {
+        } catch (e: InvocationTargetException) {
             Assertions.assertTrue(false) { errorMessage }
         }
     }

--- a/WarmUp/isWinFunction/test/Tests.kt
+++ b/WarmUp/isWinFunction/test/Tests.kt
@@ -6,12 +6,15 @@ import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import util.*
 import java.lang.reflect.InvocationTargetException
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         @JvmStatic
@@ -57,6 +60,11 @@ class Test {
             Arguments.of(false, 5, 4, false, true),
             Arguments.of(false, 3, 4, false, false),
         )
+    }
+
+    @Test
+    fun smokeTest() {
+        runMainFunction(::main, "ABCD$newLineSymbol")
     }
 
     @Test

--- a/WarmUp/playGameMain/test/Tests.kt
+++ b/WarmUp/playGameMain/test/Tests.kt
@@ -4,11 +4,14 @@ import org.jetbrains.academy.test.system.core.invokeWithArgs
 import org.jetbrains.academy.test.system.core.invokeWithoutArgs
 import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.BeforeAll
 import util.*
 import java.lang.reflect.InvocationTargetException
 
+@HandleNotImplementedError(["countPartialMatches", "countExactMatches"])
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         private lateinit var mainClazz: Class<*>
@@ -18,6 +21,11 @@ class Test {
         fun beforeAll() {
             mainClazz = mainClass.findClassSafe() ?: throwInternalCourseError()
         }
+    }
+
+    @Test
+    fun smokeTest() {
+        runMainFunction(::main, "ABCD$newLineSymbol")
     }
 
     @Test

--- a/WarmUp/printRoundResults/test/Tests.kt
+++ b/WarmUp/printRoundResults/test/Tests.kt
@@ -6,12 +6,15 @@ import org.jetbrains.academy.test.system.core.models.classes.findClassSafe
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import util.*
 import java.lang.reflect.InvocationTargetException
 
+@HandleNotImplementedError
+@ExtendWith(HandleNotImplementedErrorExtension::class)
 class Test {
     companion object {
         @JvmStatic
@@ -47,6 +50,11 @@ class Test {
         fun beforeAll() {
             mainClazz = mainClass.findClassSafe() ?: throwInternalCourseError()
         }
+    }
+
+    @Test
+    fun smokeTest() {
+        runMainFunction(::main, "ABCD$newLineSymbol")
     }
 
     @Test

--- a/gifs/src/main/kotlin/jetbrains/kotlin/course/gifs/warmup/runners/Game.kt
+++ b/gifs/src/main/kotlin/jetbrains/kotlin/course/gifs/warmup/runners/Game.kt
@@ -1,13 +1,12 @@
 package jetbrains.kotlin.course.gifs.warmup.runners
 
-import jetbrains.kotlin.course.mastermind.advanced.getGameRules
-import jetbrains.kotlin.course.mastermind.advanced.playGame
+import jetbrains.kotlin.course.mastermind.advanced.*
 
 fun main() {
     val wordLength = 4
     val maxAttemptsCount = 3
     val secretExample = "ACEB"
     val alphabet = "ABCDEFGH"
-    println(getGameRules(wordLength, maxAttemptsCount, secretExample).replace(". ", ".\n"))
+    println(getGameRules(wordLength, maxAttemptsCount, secretExample).replace(". ", ".$newLineSymbol"))
     playGame("BBDH", wordLength, maxAttemptsCount, alphabet)
 }


### PR DESCRIPTION
Now students will get more useful error messages in case NotImplementedError occurs. There are three cases:
1. A non-implemented function is called directly from main().
2. A function is not implemented, but it should be.
3. A function shouldn't be implemented, but it's called.