### PR TITLE
Fix extra input after max attempts & clarify game rules

### DIFF
--- a/Hangman/CompleteTheProject/src/main/kotlin/jetbrains/kotlin/course/hangman/Main.kt
+++ b/Hangman/CompleteTheProject/src/main/kotlin/jetbrains/kotlin/course/hangman/Main.kt
@@ -19,7 +19,7 @@ fun getGameRules(wordLength: Int, maxAttemptsCount: Int) = "Welcome to the game!
 fun isWon(complete: Boolean, attempts: Int, maxAttemptsCount: Int) = complete && attempts <= maxAttemptsCount
 
 // You will use this function later
-fun isLost(complete: Boolean, attempts: Int, maxAttemptsCount: Int) = !complete && attempts > maxAttemptsCount
+fun isLost(complete: Boolean, attempts: Int, maxAttemptsCount: Int) = !complete && attempts >= maxAttemptsCount
 
 fun deleteSeparator(guess: String) = guess.replace(separator, "")
 

--- a/Hangman/CompleteTheProject/task.md
+++ b/Hangman/CompleteTheProject/task.md
@@ -15,6 +15,10 @@ fun playGame(secret: String, maxAttemptsCount: Int): Unit
 ```
 </div>
 
+Each valid user input (a single English letter) counts as one attempt. Invalid inputs should not be counted as attempts.
+
+The game should end when the user guesses the word or uses all attempts. After that, the game should stop without asking for more input.
+
 At the end of the game, the user should be informed about the results:
 - if the user lost: `Sorry, you lost! My word is <secret>`
 - if the user guessed the word: `Congratulations! You guessed it!`

--- a/Hangman/CompleteTheProject/task.md
+++ b/Hangman/CompleteTheProject/task.md
@@ -15,9 +15,9 @@ fun playGame(secret: String, maxAttemptsCount: Int): Unit
 ```
 </div>
 
-Each valid user input (a single English letter) counts as one attempt. Invalid inputs should not be counted as attempts.
+Each valid user input (a single English letter) counts as one attempt. Invalid inputs do not count toward the attempt limit.
 
-The game should end when the user guesses the word or uses all attempts. After that, the game should stop without asking for more input.
+The game ends when the user either guesses the word or exhausts all attempts. At that point, the program should terminate without requesting further input.
 
 At the end of the game, the user should be informed about the results:
 - if the user lost: `Sorry, you lost! My word is <secret>`

--- a/Hangman/CompleteTheProject/test/Tests.kt
+++ b/Hangman/CompleteTheProject/test/Tests.kt
@@ -111,7 +111,7 @@ class Test {
 
     @Test
     fun smokeTest() {
-        runMainFunction(::main, List(maxAttemptsCount + 1) { "A$newLineSymbol" }.joinToString(""))
+        runMainFunction(::main, List(maxAttemptsCount) { "A$newLineSymbol" }.joinToString(""))
     }
 
     @ParameterizedTest

--- a/Hangman/Core/src/main/kotlin/jetbrains/kotlin/course/hangman/Main.kt
+++ b/Hangman/Core/src/main/kotlin/jetbrains/kotlin/course/hangman/Main.kt
@@ -19,7 +19,7 @@ fun getGameRules(wordLength: Int, maxAttemptsCount: Int) = "Welcome to the game!
 fun isWon(complete: Boolean, attempts: Int, maxAttemptsCount: Int) = complete && attempts <= maxAttemptsCount
 
 // You will use this function later
-fun isLost(complete: Boolean, attempts: Int, maxAttemptsCount: Int) = !complete && attempts > maxAttemptsCount
+fun isLost(complete: Boolean, attempts: Int, maxAttemptsCount: Int) = !complete && attempts >= maxAttemptsCount
 
 fun deleteSeparator(guess: String) = guess.replace(separator, "")
 

--- a/Hangman/CreateTheGame/src/main/kotlin/jetbrains/kotlin/course/hangman/Main.kt
+++ b/Hangman/CreateTheGame/src/main/kotlin/jetbrains/kotlin/course/hangman/Main.kt
@@ -19,7 +19,7 @@ fun getGameRules(wordLength: Int, maxAttemptsCount: Int) = "Welcome to the game!
 fun isWon(complete: Boolean, attempts: Int, maxAttemptsCount: Int) = complete && attempts <= maxAttemptsCount
 
 // You will use this function later
-fun isLost(complete: Boolean, attempts: Int, maxAttemptsCount: Int) = !complete && attempts > maxAttemptsCount
+fun isLost(complete: Boolean, attempts: Int, maxAttemptsCount: Int) = !complete && attempts >= maxAttemptsCount
 
 fun main() {
     // Uncomment this code on the last step of the game

--- a/Hangman/generateSecretFunction/src/main/kotlin/jetbrains/kotlin/course/hangman/Main.kt
+++ b/Hangman/generateSecretFunction/src/main/kotlin/jetbrains/kotlin/course/hangman/Main.kt
@@ -19,7 +19,7 @@ fun getGameRules(wordLength: Int, maxAttemptsCount: Int) = "Welcome to the game!
 fun isWon(complete: Boolean, attempts: Int, maxAttemptsCount: Int) = complete && attempts <= maxAttemptsCount
 
 // You will use this function later
-fun isLost(complete: Boolean, attempts: Int, maxAttemptsCount: Int) = !complete && attempts > maxAttemptsCount
+fun isLost(complete: Boolean, attempts: Int, maxAttemptsCount: Int) = !complete && attempts >= maxAttemptsCount
 
 fun deleteSeparator(guess: String) = guess.replace(separator, "")
 

--- a/Hangman/getHiddenSecretFunction/src/main/kotlin/jetbrains/kotlin/course/hangman/Main.kt
+++ b/Hangman/getHiddenSecretFunction/src/main/kotlin/jetbrains/kotlin/course/hangman/Main.kt
@@ -19,7 +19,7 @@ fun getGameRules(wordLength: Int, maxAttemptsCount: Int) = "Welcome to the game!
 fun isWon(complete: Boolean, attempts: Int, maxAttemptsCount: Int) = complete && attempts <= maxAttemptsCount
 
 // You will use this function later
-fun isLost(complete: Boolean, attempts: Int, maxAttemptsCount: Int) = !complete && attempts > maxAttemptsCount
+fun isLost(complete: Boolean, attempts: Int, maxAttemptsCount: Int) = !complete && attempts >= maxAttemptsCount
 
 fun deleteSeparator(guess: String) = guess.replace(separator, "")
 

--- a/Hangman/getRoundResultsFunction/src/main/kotlin/jetbrains/kotlin/course/hangman/Main.kt
+++ b/Hangman/getRoundResultsFunction/src/main/kotlin/jetbrains/kotlin/course/hangman/Main.kt
@@ -19,7 +19,7 @@ fun getGameRules(wordLength: Int, maxAttemptsCount: Int) = "Welcome to the game!
 fun isWon(complete: Boolean, attempts: Int, maxAttemptsCount: Int) = complete && attempts <= maxAttemptsCount
 
 // You will use this function later
-fun isLost(complete: Boolean, attempts: Int, maxAttemptsCount: Int) = !complete && attempts > maxAttemptsCount
+fun isLost(complete: Boolean, attempts: Int, maxAttemptsCount: Int) = !complete && attempts >= maxAttemptsCount
 
 fun deleteSeparator(guess: String) = guess.replace(separator, "")
 

--- a/Hangman/isCompleteFunction/src/main/kotlin/jetbrains/kotlin/course/hangman/Main.kt
+++ b/Hangman/isCompleteFunction/src/main/kotlin/jetbrains/kotlin/course/hangman/Main.kt
@@ -19,7 +19,7 @@ fun getGameRules(wordLength: Int, maxAttemptsCount: Int) = "Welcome to the game!
 fun isWon(complete: Boolean, attempts: Int, maxAttemptsCount: Int) = complete && attempts <= maxAttemptsCount
 
 // You will use this function later
-fun isLost(complete: Boolean, attempts: Int, maxAttemptsCount: Int) = !complete && attempts > maxAttemptsCount
+fun isLost(complete: Boolean, attempts: Int, maxAttemptsCount: Int) = !complete && attempts >= maxAttemptsCount
 
 fun deleteSeparator(guess: String) = guess.replace(separator, "")
 

--- a/Hangman/isCorrectInputFunction/src/main/kotlin/jetbrains/kotlin/course/hangman/Main.kt
+++ b/Hangman/isCorrectInputFunction/src/main/kotlin/jetbrains/kotlin/course/hangman/Main.kt
@@ -19,7 +19,7 @@ fun getGameRules(wordLength: Int, maxAttemptsCount: Int) = "Welcome to the game!
 fun isWon(complete: Boolean, attempts: Int, maxAttemptsCount: Int) = complete && attempts <= maxAttemptsCount
 
 // You will use this function later
-fun isLost(complete: Boolean, attempts: Int, maxAttemptsCount: Int) = !complete && attempts > maxAttemptsCount
+fun isLost(complete: Boolean, attempts: Int, maxAttemptsCount: Int) = !complete && attempts >= maxAttemptsCount
 
 fun deleteSeparator(guess: String) = guess.replace(separator, "")
 

--- a/Hangman/safeUserInputFunction/src/main/kotlin/jetbrains/kotlin/course/hangman/Main.kt
+++ b/Hangman/safeUserInputFunction/src/main/kotlin/jetbrains/kotlin/course/hangman/Main.kt
@@ -19,7 +19,7 @@ fun getGameRules(wordLength: Int, maxAttemptsCount: Int) = "Welcome to the game!
 fun isWon(complete: Boolean, attempts: Int, maxAttemptsCount: Int) = complete && attempts <= maxAttemptsCount
 
 // You will use this function later
-fun isLost(complete: Boolean, attempts: Int, maxAttemptsCount: Int) = !complete && attempts > maxAttemptsCount
+fun isLost(complete: Boolean, attempts: Int, maxAttemptsCount: Int) = !complete && attempts >= maxAttemptsCount
 
 fun deleteSeparator(guess: String) = guess.replace(separator, "")
 


### PR DESCRIPTION
This PR fixes an issue where the game requested one extra input after the maximum number of attempts was reached.

- Updated the` isLost` function to correctly end the game when all attempts are used (>= instead of >), preventing an extra input request.
- Fixed the smokeTest, which previously expected `maxAttemptsCount + 1 `inputs.
- Improved the task description by clarifying how attempts are counted and when the game should stop, to avoid confusion.