### PR TITLE
Fix inconsistent spacing in test examples and clarify instructions

### DIFF
--- a/LastPush/CanvasGapsGenerator/task.md
+++ b/LastPush/CanvasGapsGenerator/task.md
@@ -41,12 +41,12 @@ The resulting 5 x 3 picture will be:
             X     X     X         X     X     X 
 1st level: / \   / \   / \       / \   / \   / \
            \ /   \ /   \ /       \ /   \ /   \ /
-            X     X     X         X     X     X
-               X     X              / \   / \
-2nd level:    / \   / \             \ /   \ /    
-              \ /   \ /              X     X
+            X     X     X         X     X     X 
+               X     X              / \   / \   
+2nd level:    / \   / \             \ /   \ /   
+              \ /   \ /              X     X    
                X     X           / \   / \   / \
-            X     X     X        \ /   \ /   \ /    
+            X     X     X        \ /   \ /   \ /
 3rd level: / \   / \   / \        X     X     X 
            \ /   \ /   \ /
             X     X     X 
@@ -55,14 +55,26 @@ The resulting 5 x 3 picture will be:
 None of the levels of the generated image change the pattern.
 </div>
 
-The following functions will _not be checked_, but they can help you implement this project:
+The following function will _not be checked_, but it can help you implement this project:
 
 
-- `repeatHorizontallyWithGaps`, which accepts a `pattern` and the number of times that pattern should be repeated horizontally (n), e.g.:
+- `repeatHorizontallyWithGaps` repeats each row of the pattern horizontally n times, adding gaps between copies.
+The function works row by row and the result depends on the `startsWithPattern` flag:
+
+   `startsWithPattern = true` — the row starts with the pattern
+   `startsWithPattern = false` — the row starts with a gap (separator)
+
+Example (`startsWithPattern = true`, `n = 5`):
 ```text
-n = 5
 ○○             ○○  ○○  ○○
 ○○    ---->    ○○  ○○  ○○
+```
+
+Example (`startsWithPattern = false`, `n = 5`):
+
+```text
+○○               ○○  ○○    
+○○    ---->      ○○  ○○    
 ```
 
 If you have any difficulties, **hints will help you solve this task**.

--- a/LastPush/CanvasGapsGenerator/task.md
+++ b/LastPush/CanvasGapsGenerator/task.md
@@ -55,11 +55,11 @@ The resulting 5 x 3 picture will be:
 None of the levels of the generated image change the pattern.
 </div>
 
-The following function will _not be checked_, but it can help you implement this project:
+The following function will _not be checked_, but it may be helpful for your implementation:
 
 
-- `repeatHorizontallyWithGaps` repeats each row of the pattern horizontally n times, adding gaps between copies.
-The function works row by row and the result depends on the `startsWithPattern` flag:
+- `repeatHorizontallyWithGaps` repeats each row of the pattern horizontally `n` times, inserting gaps between the copies.
+  The function processes data row by row, and the output format is determined by the `startsWithPattern` flag:
 
    `startsWithPattern = true` — the row starts with the pattern
    `startsWithPattern = false` — the row starts with a gap (separator)

--- a/LastPush/CanvasGenerator/task.md
+++ b/LastPush/CanvasGenerator/task.md
@@ -44,14 +44,14 @@ The resulting 5 x 3 picture will be:
 1st level: / \/ \/ \/ \/ \       / \/ \/ \/ \/ \
            \ /\ /\ /\ /\ /       \ /\ /\ /\ /\ /
             X  X  X  X  X         X  X  X  X  X 
-2nd level: / \/ \/ \/ \/ \        X  X  X  X  X
+2nd level: / \/ \/ \/ \/ \        X  X  X  X  X 
            \ /\ /\ /\ /\ /       / \/ \/ \/ \/ \
-            X  X  X  X  X        \ /\ /\ /\ /\ / 
+            X  X  X  X  X        \ /\ /\ /\ /\ /
 3rd level: / \/ \/ \/ \/ \        X  X  X  X  X 
            \ /\ /\ /\ /\ /        X  X  X  X  X 
-            X  X  X  X  X        / \/ \/ \/ \/ \ 
-                                 \ /\ /\ /\ /\ / 
-                                  X  X  X  X  X
+            X  X  X  X  X        / \/ \/ \/ \/ \
+                                 \ /\ /\ /\ /\ /
+                                  X  X  X  X  X 
 ```
 
 The first line of the initial pattern was removed from the second level and beyond.
@@ -62,7 +62,7 @@ However, if the size is 5 x 1, the resulting picture will be:
 ```text
             CORRECT:             INCORRECT:
  
-            X  X  X  X  X         X  X  X  X  X
+            X  X  X  X  X         X  X  X  X  X 
 1st level: / \/ \/ \/ \/ \       / \/ \/ \/ \/ \
            \ /\ /\ /\ /\ /       \ /\ /\ /\ /\ /
             X  X  X  X  X 

--- a/LastPush/Helpers/task.md
+++ b/LastPush/Helpers/task.md
@@ -2,7 +2,7 @@ In the upcoming steps, we will implement some helper functions to create the app
 
 ### Task
 
-Implement the `fillPatternRow` function, which accepts a `patternRow` (a single line of the pattern) and `patternWidth`
+Implement the `fillPatternRow` function, which accepts a `patternRow` (a single line of the pattern) and the `patternWidth`
 and adds the row `separator` to extend the line to the `patternWidth` size.
 
 <div class="hint" title="Click me to see the new signature of the getPatternHeight function">

--- a/LastPush/Helpers/task.md
+++ b/LastPush/Helpers/task.md
@@ -2,7 +2,7 @@ In the upcoming steps, we will implement some helper functions to create the app
 
 ### Task
 
-Implement the `fillPatternRow` function, which accepts a `patternRow` (one image from the pattern) and `patternWidth`
+Implement the `fillPatternRow` function, which accepts a `patternRow` (a single line of the pattern) and `patternWidth`
 and adds the row `separator` to extend the line to the `patternWidth` size.
 
 <div class="hint" title="Click me to see the new signature of the getPatternHeight function">

--- a/LastPush/dropTopLineFunction/task.md
+++ b/LastPush/dropTopLineFunction/task.md
@@ -3,9 +3,10 @@ In such cases, we need to remove the top line.
 
 ### Task
 
-Implement the `dropTopLine` function, which accepts an `image` (any string; can be multi-row),
-the `width` (how many times the pattern was repeated horizontally),
-`patternHeight`, and `patternWidth` and returns the image without its first line.
+Implement the `dropTopLine` function, which accepts an `image` (a string that may contain multiple rows),
+the `width` (the number of times the pattern was repeated horizontally),
+the `patternHeight`, and the `patternWidth`. It should return the image with its first line removed.
+
 For example (for `width` = 1):
 ```text
    .+------+              

--- a/LastPush/dropTopLineFunction/task.md
+++ b/LastPush/dropTopLineFunction/task.md
@@ -3,18 +3,18 @@ In such cases, we need to remove the top line.
 
 ### Task
 
-Implement the `dropTopLine` function, which accepts an `image` (any string; can be multi-row), 
-the `width` of the new image that should be created (`image` should have already been repeated `width` times),
-`patternHeight`, and `patternWidth`. This function deletes the first line,
-e.g., (for `width` = 1):
+Implement the `dropTopLine` function, which accepts an `image` (any string; can be multi-row),
+the `width` (how many times the pattern was repeated horizontally),
+`patternHeight`, and `patternWidth` and returns the image without its first line.
+For example (for `width` = 1):
 ```text
-   .+------+                 
+   .+------+              
  .' |    .'|                .' |    .'|
 +---+--+'  |    ----->     +---+--+'  |
 |   |  |   |               |   |  |   |
 |  ,+--+---+               |  ,+--+---+
 |.'    | .'                |.'    | .' 
-+------+'                  +------+'
++------+'                  +------+'   
 ```
 
 


### PR DESCRIPTION
Improved several task descriptions that can be unclear for learners (tested on myself):

1) Simplified explanations of `patternWidth` in the `fillPatternRow` function and `width` in the `dropTopLine` function
2) Added a clearer explanation of what `repeatHorizontallyWithGaps` should do, along with examples
3) Added missing trailing spaces to ensure consistent layer width. This prevents confusion when comparing expected vs actual output in test examples (reported by a student)