### PR TITLE
Fix error with jdk 26

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,16 @@ allprojects {
         plugin("com.github.johnrengelman.shadow")
     }
 
+    java {
+        toolchain {
+            languageVersion.set(JavaLanguageVersion.of(21))
+        }
+    }
+
+    kotlin {
+        jvmToolchain(21)
+    }
+
     repositories {
         mavenCentral()
         maven {


### PR DESCRIPTION
The `build.gradle.kts` file has been updated, so when the tasks are actually run, Java 21 will be used.