### PR TITLE
EDC-1356: do not use gradle `toolchain` API to specify required jvm

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -8,10 +8,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3.0.0
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3.0.0
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
       - name: Gradle Wrapper Validation
         uses: gradle/actions/wrapper-validation@v3

--- a/.github/workflows/gradle-test.yml
+++ b/.github/workflows/gradle-test.yml
@@ -8,10 +8,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3.0.0
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3.0.0
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
       - name: Gradle Wrapper Validation
         uses: gradle/actions/wrapper-validation@v3

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,6 @@
 import org.jetbrains.kotlin.config.KotlinCompilerVersion
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     java
@@ -36,13 +38,8 @@ allprojects {
     }
 
     java {
-        toolchain {
-            languageVersion.set(JavaLanguageVersion.of(21))
-        }
-    }
-
-    kotlin {
-        jvmToolchain(21)
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
 
     repositories {
@@ -65,6 +62,12 @@ allprojects {
     }
 
     tasks {
+        withType<KotlinCompile> {
+            compilerOptions {
+                // Keep in sync with source/target versions in `java` block above
+                jvmTarget = JvmTarget.JVM_21
+            }
+        }
 
         withType<Test> {
             useJUnitPlatform()

--- a/course-info.yaml
+++ b/course-info.yaml
@@ -22,7 +22,7 @@ content:
 tags:
   - Beginner-friendly
 environment_settings:
-  jvm_language_level: JDK_17
+  jvm_language_level: JDK_21
 additional_files:
   - name: utils/build.gradle.kts
   - name: utils/src/main/kotlin/util/Util.kt


### PR DESCRIPTION
The corresponding API forces users to use JVM with exact specified version. It causes issues in JetBrains Academy plugin because it doesn't know about these strict rules and sets up based on `jvm_language_level` field from `course-info.yaml` and gradle version

Update `jvm_language_level` as well.


After these changes, course should support any JDK >= 21. I'm not sure what exactly didn't work with JDK 26 (see #260). It seems everything works fine with my changes even with jdk 26